### PR TITLE
Fixing TERM Variable for 256 colors within tmux

### DIFF
--- a/bashrc.sh
+++ b/bashrc.sh
@@ -60,7 +60,8 @@ if [ -n "$PS1" ] &&
     [[ ! "$TERM" =~ tmux ]] &&
     [ -z "$TMUX" ] &&
     ! [ -e ~/storage/shared ]; then
-
+    
+    export TERM="screen-256color"
     if [[ "$SHELL" == *"bash" ]]; then
         exec tmux
     else


### PR DESCRIPTION
By default tmux uses TERM=screen, which breaks some applications and colorschemes, like vifm and so on.

![image](https://user-images.githubusercontent.com/2071597/95788178-50543880-0cdb-11eb-8b08-696e1023b6cd.png)

Setting TERM to screen-256color fixes that.