### PR TITLE
Make notifications work with multi-monitor

### DIFF
--- a/dunstrc
+++ b/dunstrc
@@ -14,6 +14,7 @@
 	mouse_middle_click = close_all
 	mouse_right_click = close_current
 	format = "<b>%s</b>\n%b"
+	follow = keyboard
 	show_indicators = yes
 	dmenu = /usr/bin/instantmenu -q "notification menu" -l 10 -w -1 -x 1000000 -bw 5 -y 32
 


### PR DESCRIPTION
By default, dunst puts all notifications on the first monitor, which is annoying with 2 monitors. This makes the notifications show up on the monitor with the focused window, so the notifications should show up on the monitor you're using.