### PR TITLE
fix terminal crash when tmux missing

### DIFF
--- a/bashrc.sh
+++ b/bashrc.sh
@@ -59,8 +59,9 @@ if [ -n "$PS1" ] &&
     [[ ! "$TERM" =~ screen ]] &&
     [[ ! "$TERM" =~ tmux ]] &&
     [ -z "$TMUX" ] &&
-    ! [ -e ~/storage/shared ]; then
-
+    ! [ -e ~/storage/shared ] &&
+    command -v tmux 2>&1 1>/dev/null
+then
     if [[ "$SHELL" == *"bash" ]]; then
         exec tmux
     else


### PR DESCRIPTION
Some users might uninstall tmux without realizing it is required for the terminal to work. With this change, we get a normal bash instead of crashing the terminal emulator.