### PR TITLE
Add appmenu scrollbar functionality

### DIFF
--- a/rootconfig/rofi/appmenu.rasi
+++ b/rootconfig/rofi/appmenu.rasi
@@ -71,6 +71,15 @@ listview {
     cycle:                          false;
     dynamic:                        true;
     layout:                         vertical;
+    scrollbar: 			            true;
+}
+
+scrollbar {
+    width:        		            4px ;
+    border:       		            0;
+    handle-color: 		            @foreground;
+    handle-width: 		            8px ;
+    padding:      		            0;
 }
 
 mainbox {


### PR DESCRIPTION
Added scrollbar functionatlity to graphical appmenu of instantOS to enhance touch screen experience by enabling to scroll without needing keyboard / mouse input.

~~Note: This will overwrite scrolling from left to right to be scrolling up and down instead.~~